### PR TITLE
Tray fixes

### DIFF
--- a/src-ui/app/services/system-tray.service.ts
+++ b/src-ui/app/services/system-tray.service.ts
@@ -79,6 +79,18 @@ export class SystemTrayService {
           item: 'Separator',
         },
         {
+          text: this.translateService.instant('systemTray.showWindow'),
+          action: async () => {
+            const { getCurrentWindow } = await import('@tauri-apps/api/window');
+            const win = getCurrentWindow();
+            await win.show();
+            await win.setFocus();
+          },
+        },
+        {
+          item: 'Separator',
+        },
+        {
           text: this.translateService.instant('systemTray.sleepMode'),
           checked: await firstValueFrom(this.sleepService.mode),
           action: async () => {
@@ -103,7 +115,10 @@ export class SystemTrayService {
         },
         {
           text: this.translateService.instant('systemTray.quit'),
-          item: 'Quit',
+          action: async () => {
+            const { exit } = await import('@tauri-apps/plugin-process');
+            await exit(0);
+          },
         },
       ],
     });

--- a/src-ui/assets/i18n/en.json
+++ b/src-ui/assets/i18n/en.json
@@ -1192,7 +1192,7 @@
         "description": "Apply the following MSI Afterburner profile",
         "title": "When sleep mode is disabled"
       },
-        "sleepPreparation": {
+      "sleepPreparation": {
         "description": "Apply the following MSI profile",
         "title": "When Preparing to sleep"
       },
@@ -1216,7 +1216,6 @@
         "description": "Apply the following LACT profile",
         "title": "When sleep mode is enabled"
       }
-      
     },
     "powerLimiting": {
       "activatingSleepMode": {
@@ -1866,9 +1865,9 @@
         "description": "Set the following Power Policy",
         "title": "When Preparing to sleep"
       },
-      "provider":{
-          "title":"provider",
-          "description": "Select which program should be used to controll system's power policy"
+      "provider": {
+        "title": "provider",
+        "description": "Select which program should be used to controll system's power policy"
       }
     }
   },
@@ -1897,7 +1896,7 @@
     },
     "title": "Resolution Automations"
   },
-  "playbackAutomations":{
+  "playbackAutomations": {
     "title": "Playback Automations",
     "description": "OyasumiVR can automatically pause mrpis compatible players"
   },
@@ -2912,7 +2911,8 @@
   "systemTray": {
     "prepareForSleep": "Prepare for sleep",
     "quit": "Quit OyasumiVR",
-    "sleepMode": "Sleep Mode"
+    "sleepMode": "Sleep Mode",
+    "showWindow": "Open OyasumiVR"
   },
   "updater": {
     "modals": {


### PR DESCRIPTION
It seems that Tauri doesn't distinguish with which mouse button the tray icon was pressed on Linux, so it's not possible to replicate how the tray icon acts on Windows. As a workaround, I've added a button to show the window to the context menu, as well as fixed the Quit button not being shown.