### PR TITLE
Migrate to vrchat_osc 2.0.0

### DIFF
--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -53,7 +53,6 @@ readonly = "0.2.13"
 regex = "1.12.2"
 reqwest = "0.12.24"
 rodio = "0.20.1"
-rosc = "0.11.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 steamlocate ="2.0.1"
@@ -90,7 +89,7 @@ urlencoding = "2.1.3"
 uuid = { version = "1.18.1", features = [
     "v4",
 ] }
-vrchat_osc = { git = "https://github.com/minetake01/vrchat_osc", version = "1.3.0" }
+vrchat_osc = "2.0"
 serde_repr = "0.1.20"
 glam = "0.30.9"
 

--- a/src-core/src/osc/commands.rs
+++ b/src-core/src/osc/commands.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use log::debug;
-use rosc::{OscMessage, OscPacket, OscType};
+use vrchat_osc::rosc::{OscMessage, OscPacket, OscType};
 use tokio::{spawn, sync::Mutex};
 use vrchat_osc::{
     models::{OscNode, OscRootNode},
@@ -126,7 +126,7 @@ pub async fn set_osc_receive_address_whitelist(whitelist: Vec<String>) {
         }
     }
    
-    let vrchat_osc = VRChatOSC::new().await.unwrap();
+    let vrchat_osc = VRChatOSC::new(None).await.unwrap();
     let mut root_node = OscRootNode::new();
     for path in whitelist {
         root_node = root_node.add_node(OscNode {
@@ -136,7 +136,7 @@ pub async fn set_osc_receive_address_whitelist(whitelist: Vec<String>) {
     }
     vrchat_osc.on_connect(|service|{
         match service{
-            vrchat_osc::ServiceType::Osc(name, socket_addr) => {if name.to_utf8().starts_with("VRChat-Client-"){
+            vrchat_osc::ServiceType::Osc(name, socket_addr) => {if name.starts_with("VRChat-Client-"){
                 log::debug!("new osc service {}:{}",name,socket_addr);
                 spawn(send_event("VRC_OSC_ADDRESS_CHANGED", socket_addr.to_string()));
                  VRCHAT_OSC_ADDR.lock().unwrap().replace(socket_addr);


### PR DESCRIPTION
## Summary
This PR updates the project to use `vrchat_osc` version 2.0.0, which includes breaking changes in the API.

## Changes
- Updated `vrchat_osc` git dependency version from `1.3.0` to `2.0.0`
- Updated `VRChatOSC::new()` to `VRChatOSC::new(None)` in `src-core/src/osc/commands.rs`
- Fixed `ServiceType::Osc` handler: removed `.to_utf8()` call since `name` is now a `String` instead of `Name` type
- Migrated to use re-exported `rosc` types from `vrchat_osc::rosc` instead of direct dependency

## Breaking Changes Addressed
The major breaking changes in `vrchat_osc` 2.0.0 include:
- `VRChatOSC::new()` now requires an `Option<String>` parameter for the destination IP address
- `ServiceType` enum's first value type changed from `Name` to `String` (no longer requires `.to_utf8()`)
- The `rosc` crate is now re-exported by `vrchat_osc`

## Optional Enhancement
If you wish to send OSC messages to VRChat running on a different machine (not localhost), you can now specify the destination IP address:

```rust
let vrchat_osc = VRChatOSC::new(Some("192.168.1.100".to_string())).await?;
```

This could be useful for:
- Multi-PC VR configurations
- Remote control and monitoring scenarios
- Network-based sleep tracking setups

For more details on why this change was necessary, please refer to:
https://github.com/minetake01/vrchat_osc/blob/master/WORKAROUNDS.md#issue-1-advertising-127001-on-all-interfaces

## Note on Cargo.lock
Cargo.lock is not included in this PR due to complex dependency resolution issues unrelated to this change.
Running `cargo build` will generate a new lock file with the updated vrchat_osc dependency.